### PR TITLE
Require the stdlib modules we use.

### DIFF
--- a/lib/cisco_spark.rb
+++ b/lib/cisco_spark.rb
@@ -1,3 +1,6 @@
+require "forwardable"
+require "date"
+
 require "cisco_spark/configuration"
 require "cisco_spark/errors"
 require "cisco_spark/utils"


### PR DESCRIPTION
This prevents errors when a user attempts to load cisco_spark-ruby.  Pulling in required modules should be the responsibility of the code that uses them, not the calling code.